### PR TITLE
Make sure UTF-8 works in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-sudo: require
-
-language: bash
+language: generic
 
 branches:
     only:
@@ -9,14 +7,16 @@ branches:
 notifications:
     email: false
 
+dist: xenial
+
+addons:
+    apt:
+        packages:
+            - texlive-full
+
 env:
     global:
-        # Github Token for pushing the built docs (GH_TOKEN)
         - secure: "N0Rt5VNq5rX2uwlltUws0Sj03elzpIeYP4hYQkimmBfUnU5Cjw1seWEXYFZghvr4YZhoTYrmDv1DZsity3go7UCFy5/ZLkYl418ev7sOdQT2yA1hjAoNgFyRyXoJZLmUVaEDUYv/QQUBnMtE44F58SdGBPKbkY/epU7AvmvUgSw="
-
-before_install:
-    - sudo apt-get -q update
-    - sudo apt-get install -y texlive-full
 
 script:
     - make

--- a/leonardo_uieda_cv.tex
+++ b/leonardo_uieda_cv.tex
@@ -116,9 +116,7 @@
 \usepackage[usenames,dvipsnames]{xcolor}
 
 % Set fonts. Requires compilation with xelatex
-%\usepackage{fontspec}
-%\setmainfont[BoldFont=SourceSansPro-Semibold]{SourceSansPro-Light}
-%\setmonofont{Source Code Pro}
+\usepackage{fontspec}  % required to make older xelatex compile with UTF8
 
 % Configure the font style for sections
 \usepackage{sectsty}


### PR DESCRIPTION
Use the `apt` addon to install texlive and import `fontspec` to make sure
older xelatex uses UTF8 correctly.